### PR TITLE
Modify k8s-ruby to support OIDC structure 

### DIFF
--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -94,9 +94,9 @@ module K8s
     # @param auth_provider [K8s::Config::UserAuthProvider]
     # @return [String]
     def self.token_from_auth_provider(auth_provider)
-      auth_data = `#{auth_provider['cmd-path']} #{auth_provider['cmd-args']}`.strip
-      if auth_provider['token-key']
-        json_path = JsonPath.new(auth_provider['token-key'][1...-1])
+      auth_data = `#{auth_provider['config']['cmd-path']} #{auth_provider['config']['cmd-args']}`.strip
+      if auth_provider['config']['token-key']
+        json_path = JsonPath.new(auth_provider['config']['token-key'][1...-1])
         json_path.first(auth_data)
       else
         auth_data


### PR DESCRIPTION
The current way of supporting auth-provider looks completely wrong. The existing function is causing issues, as it's looking for some config elements that are missing. Modifying pathing to find the credentials and values have been made